### PR TITLE
Fixes for Julia0.7 and 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,9 @@
+name = "DFTShims"
+uuid = "a001f356-ac7d-5fb9-adbb-c1ca3b4a7e48"
+version = "0.0.0"
+
+[deps]
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/ArrayInitialization.jl
+++ b/src/ArrayInitialization.jl
@@ -11,6 +11,7 @@ using ..Traits: components, ColinearSpin, SpinDegenerate, SpinCategory, Colinear
                 SpinAware
 using ..Dispatch
 export wrap
+import AxisArrays: axes
 
 macro lintpragma(s) end
 @lintpragma("Ignore unused args")
@@ -98,7 +99,7 @@ for extension in [:zeros, :ones, :rand]
     @eval begin
         """
         Creates an array for the given DFT quantity
-        
+
         The spin axis is automatically added if required. Neither `dims` nor `ax` should
         include the spin dimension.
         """
@@ -227,7 +228,7 @@ end
 
 Base.reinterpret(T::Type{<: DD.Scalars.All}, ::SpinDegenerate, array::DenseArray) =
     AxisArray(reinterpret(concretize_type(T, array), array), axes(array))
-Base.reinterpret(T::Type{<: DD.Scalars.All}, ::ColinearSpinFirst, array::DenseArray) = 
+Base.reinterpret(T::Type{<: DD.Scalars.All}, ::ColinearSpinFirst, array::DenseArray) =
     AxisArray(reinterpret(concretize_type(T, array), array),
               Axis{:spin}(components(T, ColinearSpinFirst())), Base.tail(axes(array))...)
 Base.reinterpret(T::Type{<: DD.Scalars.All}, C::ColinearSpin, array::DenseArray) =

--- a/src/ArrayInitialization.jl
+++ b/src/ArrayInitialization.jl
@@ -53,7 +53,7 @@ axis, or 0 if there are none.
 """
 spin_axis_position(::Type{ColinearSpin{T}}, ::Integer, ::Integer) where T = T
 spin_axis_position(::Type{ColinearSpinLast}, n::Integer, s::Integer) =
-    !(1 ≤ s ≤ n) ? n + 1: n
+    !(1 ≤ s ≤ n) ? n + 1 : n
 spin_axis_position(S::SpinCategory, n::Integer, s::Integer) =
     spin_axis_position(typeof(S), n, s)
 spin_axis_position(array::DD.AxisArrays.All) = findfirst(is_spin_polarized, axes(array))
@@ -111,7 +111,7 @@ for extension in [:zeros, :ones, :rand]
             # we can use a dummy array here since the underlying array (and indices) will be
             # the standard one
             defaults = AxisArrays.default_axes(ConstantArray(0, dims), ax)
-            AxisArray(reinterpret(T, data), add_spin_axis(C, defaults, Axis{:spin}(comps)))
+            AxisArray(collect(reinterpret(T, data)), add_spin_axis(C, defaults, Axis{:spin}(comps)))
         end
         Base.$extension(T::Type{<:DD.Scalars.All}, C::SpinCategory, dims::Tuple) = begin
             comps = components(T, C)
@@ -135,7 +135,7 @@ for extension in [:zeros, :ones, :rand]
                 @argcheck(length(components(T, C)) == length(ax[index]),
                           "Incorrect spin components for given input type")
             end
-            AxisArray(reinterpret(T, $extension(T.parameters[1], length.(ax))), ax)
+            AxisArray(collect(reinterpret(T, $extension(T.parameters[1], length.(ax)))), ax)
         end
 
         """
@@ -161,7 +161,7 @@ for extension in [:zeros, :ones, :rand]
         end
         Base.$extension(T::Type{<:DD.Scalars.All}, polarized::Bool,
                         args::Vararg{Union{Integer, Axis}}; kwargs...) =
-            $extension(T, polarized ? ColinearSpin(): SpinDegenerate(), args...; kwargs...)
+            $extension(T, polarized ? ColinearSpin() : SpinDegenerate(), args...; kwargs...)
     end
 end
 
@@ -227,12 +227,12 @@ for extension in [:zeros, :ones, :similar]
 end
 
 Base.reinterpret(T::Type{<: DD.Scalars.All}, ::SpinDegenerate, array::DenseArray) =
-    AxisArray(reinterpret(concretize_type(T, array), array), axes(array))
+    AxisArray(collect(reinterpret(concretize_type(T, array), array)), axes(array))
 Base.reinterpret(T::Type{<: DD.Scalars.All}, ::ColinearSpinFirst, array::DenseArray) =
-    AxisArray(reinterpret(concretize_type(T, array), array),
+    AxisArray(collect(reinterpret(concretize_type(T, array), array)),
               Axis{:spin}(components(T, ColinearSpinFirst())), Base.tail(axes(array))...)
 Base.reinterpret(T::Type{<: DD.Scalars.All}, C::ColinearSpin, array::DenseArray) =
-    AxisArray(reinterpret(concretize_type(T, array), array),
+    AxisArray(collect(reinterpret(concretize_type(T, array), array)),
               Base.front(axes(array))..., Axis{:spin}(components(T, C)))
 
 """
@@ -267,7 +267,7 @@ wrap(T::Type{<: DD.Scalars.All}, array::DenseArray) =
 _convert(T::Type{<:DD.Scalars.All}, C::ColinearSpin,
          C′::ColinearSpin, array::DD.AxisArrays.All) = begin
     T′ = concretize_type(T, array)
-    (T′ == T && C == C′) ? array: copy!(similar(array, T, C), array)
+    (T′ == T && C == C′) ? array : copy!(similar(array, T, C), array)
 end
 
 """
@@ -280,7 +280,7 @@ Otherwise, a new array is returned.
 """
 Base.convert(::SpinAware, array::DD.AxisArrays.All) = array
 Base.convert(T::Type{<: DD.Scalars.All}, ::SpinAware, array::DD.AxisArrays.All) =
-    _convert(concretize_type(T, array), SpinCategory(array), SpinCategory(array), array)
+    _convert(T, array, SpinCategory(array), SpinCategory(array), array)
 Base.convert(C::ColinearSpin, array::DD.AxisArrays.All) =
     _convert(eltype(array), C, SpinCategory(array), array)
 Base.convert(T::Type{<: DD.Scalars.All}, C::SpinCategory, array::DD.AxisArrays.All) =

--- a/src/AxisArrays.v0.1.x.jl
+++ b/src/AxisArrays.v0.1.x.jl
@@ -18,13 +18,14 @@ Base.copy!(dest::AxisArray{TT, N, AA, AAs}, source::AxisArray{T, N, A, As},
         copy!(dest.data, source.data)
     else
         perm = indexin(collect(axisnames(dest)), collect(axisnames(source)))
-        any(iszero(x) for x in perm) &&
+        any(x==nothing for x in perm) &&
                 throw(ArgumentError("""
                     Axes of source and destination do not match.
                     Use copy!(A, B, false) if you want to ignore axis information.
                     """))
 
-        permutedims!(dest.data, source.data, perm)
+        #REVIEW: not sure if this is correct?
+        permutedims!(dest.data, convert.(TT, source.data), perm)
     end
     dest
 end

--- a/src/DFTShims.jl
+++ b/src/DFTShims.jl
@@ -4,7 +4,7 @@ using Unitful
 using AxisArrays
 
 # if Pkg.installed("AxisArrays") <= v"0.2.1"
-# include("AxisArrays.v0.1.x.jl")
+include("AxisArrays.v0.1.x.jl")
 # end
 
 

--- a/src/DFTShims.jl
+++ b/src/DFTShims.jl
@@ -3,9 +3,9 @@ module DFTShims
 using Unitful
 using AxisArrays
 
-if Pkg.installed("AxisArrays") <= v"0.2.1"
-    include("AxisArrays.v0.1.x.jl")
-end
+# if Pkg.installed("AxisArrays") <= v"0.2.1"
+# include("AxisArrays.v0.1.x.jl")
+# end
 
 
 include("UnitfulHartree.jl")

--- a/test/Initialization.jl
+++ b/test/Initialization.jl
@@ -1,6 +1,7 @@
 using DFTShims: ColinearSpin, SpinDegenerate, is_spin_polarized
 using AxisArrays
 using Unitful
+import AxisArrays: axes
 
 const DH = DFTShims.Dispatch.Hartree
 const Dρ = DH.Scalars.ρ
@@ -62,7 +63,7 @@ end
     actual = @inferred replace_spin_axis(Dρ, ColinearSpinLast(), (4, 3, 2), saxes)
     @test actual == ((4, 3, 2), (AXES..., Axis{:spin}((:α, :β))))
 
-    saxes = Axis{:spin}((:u, :d)), AXES... 
+    saxes = Axis{:spin}((:u, :d)), AXES...
     actual = @inferred replace_spin_axis(Dρ, ColinearSpinFirst(), (2, 3, 4), saxes)
     @test actual == ((2, 3, 4), (Axis{:spin}((:α, :β)), AXES...))
     actual = @inferred replace_spin_axis(Dρ, ColinearSpinLast(), (2, 3, 4), saxes)
@@ -97,7 +98,7 @@ end
     @test eltype(ρ) == Dρ{Int64}
     @test is_spin_polarized(ρ)
     @test @inferred(SpinCategory(ρ)) == ColinearSpinFirst()
-    
+
     ∂ϵ_∂ρ = @inferred rand(typeof(1u"eV*nm^3"), ColinearSpin{length(AXES)}(), AXES)
     @test axes(∂ϵ_∂ρ, length(AXES)) isa Axis{:spin}
     @test ndims(∂ϵ_∂ρ) == length(AXES) + 1
@@ -121,7 +122,7 @@ end
     @test eltype(zeros(ρ, DH.Scalars.∂²ϵ_∂σ²{Int64}, SpinAware())) == typeof(0u"∂²ϵ_∂σ²")
     @test is_spin_polarized(zeros(ρ, DH.Scalars.∂²ϵ_∂σ²{Int64}, SpinAware()))
     @test length(zeros(ρ, DH.Scalars.∂²ϵ_∂σ²{Int64}, SpinAware())[Axis{:spin}]) == 6
-    @test find(x -> typeof(x) <: Axis{:spin}, 
+    @test find(x -> typeof(x) <: Axis{:spin},
                axes(zeros(ρ, DH.Scalars.∂²ϵ_∂σ²{Int64}, SpinAware()))) == [length(AXES) + 1]
     @test axes(zeros(ρ, DH.Scalars.∂²ϵ_∂σ²{Int64}, SpinAware()))[1:end - 1] == AXES
     @test axes(zeros(ρ, DH.Scalars.∂²ϵ_∂σ², ColinearSpinFirst()))[2:end] == AXES
@@ -197,4 +198,3 @@ end
     @test is_spin_polarized(wrap(DD.Scalars.ρ, ColinearSpinFirst(), [1 2 3; 4 5 6]))
     @test_throws ArgumentError wrap(DD.Scalars.ρ, ColinearSpin(), [1 2 3; 4 5 6])
 end
-


### PR DESCRIPTION
All tests run on julia 0.7.0, There was one docstring bug uncovered  in `Traits.jl` which has a PR in Base julia, it's marked by the `#TODO`.

`reinterpret` returns `ReinterpretedArray` instead of `DenseArray`, maybe this should be allowed? To fix I added `collect` everywhere.

Lastly, I had to add a `convert.(...)` in a `copy!` method for `AxisArrays` to get `permutedims!` to work and give the correct `InexactError`. Please check if this is the correct fix, marked by `#REVIEW`

 